### PR TITLE
Adds isEnumValue(enumType, value)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/ts-necessities",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Small utilities to make life with TypeScript easier",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,13 @@ export function definedMap<T, U>(x: T | undefined, f: (xx: T) => U): U | undefin
 }
 
 /**
+ * If `x` belongs to the enum `e`, return `true`.  Otherwise, return `false`.
+ */
+export function isEnumValue<T>(e: T, x: unknown): x is T[keyof T] {
+    return (Object.keys(e) as Array<keyof T>).map(k => e[k]).some(v => v === x as T[keyof T]) ?? false;
+}
+
+/**
  * Returns whether `obj` has `name` as its own property.
  */
 export function hasOwnProperty<T extends string>(obj: unknown, name: T): obj is { [P in T]: unknown } {

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export function definedMap<T, U>(x: T | undefined, f: (xx: T) => U): U | undefin
  * If `x` belongs to the enum `e`, return `true`.  Otherwise, return `false`.
  */
 export function isEnumValue<T>(e: T, x: unknown): x is T[keyof T] {
-    return (Object.keys(e) as Array<keyof T>).map(k => e[k]).some(v => v === x as T[keyof T]) ?? false;
+    return (Object.keys(e) as Array<keyof T>).map(k => e[k]).some(v => v === x as T[keyof T]);
 }
 
 /**


### PR DESCRIPTION
In some of our TypeScript I've noticed a pattern emerge where for enum types, we would create a function that checked if some arbitrary value belongs to that enum.  This function genericizes that process.

Example:

```typescript
enum Color {
    Red = "red",
    Green = "green",
    Blue = "blue",
}

assert(isEnumValue(Color, Color.Red));
assert(isEnumValue(Color, "green"));
assert(!isEnumValue(Color, "orange"));
```